### PR TITLE
Fix/terminal output

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -121,15 +121,19 @@ fn get_default_ssh_key_path() -> String {
     #[cfg(target_os = "windows")]
     {
         if let Ok(userprofile) = std::env::var("USERPROFILE") {
-            format!("{}\\.ssh\\id_rsa", userprofile)
+            format!("{}\\.ssh\\id_ed25519", userprofile)
         } else {
-            "%USERPROFILE%\\.ssh\\id_rsa".to_string()
+            "%USERPROFILE%\\.ssh\\id_ed25519".to_string()
         }
     }
     
     #[cfg(not(target_os = "windows"))]
     {
-        "~/.ssh/id_rsa".to_string()
+        if let Ok(home) = std::env::var("HOME") {
+            format!("{}/.ssh/id_ed25519", home)
+        } else {
+            "~/.ssh/id_ed25519".to_string()
+        }
     }
 }
 
@@ -272,11 +276,39 @@ async fn send_terminal_input(
 async fn browse_ssh_key(app: AppHandle) -> Result<Option<String>, String> {
     use tauri_plugin_dialog::DialogExt;
     
-    let file_path = app.dialog().file()
+    // Get the default SSH directory to start the dialog in
+    let default_ssh_dir = {
+        #[cfg(target_os = "windows")]
+        {
+            if let Ok(userprofile) = std::env::var("USERPROFILE") {
+                format!("{}\\.ssh", userprofile)
+            } else {
+                "".to_string()
+            }
+        }
+        
+        #[cfg(not(target_os = "windows"))]
+        {
+            if let Ok(home) = std::env::var("HOME") {
+                format!("{}/.ssh", home)
+            } else {
+                "".to_string()
+            }
+        }
+    };
+    
+    let mut dialog = app.dialog().file()
         .set_title("Select SSH Private Key")
-        .add_filter("SSH Keys", &["*"])
-        .add_filter("All Files", &["*"])
-        .blocking_pick_file();
+        .add_filter("SSH Private Keys", &["id_rsa", "id_ed25519", "id_ecdsa", "id_dsa"])
+        .add_filter("All Files", &["*"]);
+    
+    // Set initial directory to .ssh folder if it exists
+    if !default_ssh_dir.is_empty() && std::path::Path::new(&default_ssh_dir).exists() {
+        dialog = dialog.set_directory(&default_ssh_dir);
+    }
+    
+    // On macOS, the dialog should show hidden files by default when starting in .ssh
+    let file_path = dialog.blocking_pick_file();
     
     match file_path {
         Some(path) => Ok(Some(path.to_string())),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -298,9 +298,9 @@ async fn browse_ssh_key(app: AppHandle) -> Result<Option<String>, String> {
     };
     
     let mut dialog = app.dialog().file()
-        .set_title("Select SSH Private Key")
-        .add_filter("SSH Private Keys", &["id_rsa", "id_ed25519", "id_ecdsa", "id_dsa"])
-        .add_filter("All Files", &["*"]);
+        .set_title("Select SSH Private Key");
+        // .add_filter("SSH Private Keys", &["id_rsa", "id_ed25519", "id_ecdsa", "id_dsa"])
+        // .add_filter("All Files", &["*"]);
     
     // Set initial directory to .ssh folder if it exists
     if !default_ssh_dir.is_empty() && std::path::Path::new(&default_ssh_dir).exists() {


### PR DESCRIPTION
This pull request updates SSH key handling in the `src-tauri/src/lib.rs` file to improve compatibility and user experience. The most significant changes include switching the default SSH key to `id_ed25519` and enhancing the file dialog for selecting SSH keys.

### Updates to SSH Key Handling:

* Updated the default SSH key path from `id_rsa` to `id_ed25519` for both Windows and non-Windows platforms. This change includes handling for the `HOME` environment variable on non-Windows systems to construct the path dynamically. (`[src-tauri/src/lib.rsL124-R136](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL124-R136)`)

### Enhancements to SSH Key Selection:

* Modified the `browse_ssh_key` function to initialize the file dialog in the `.ssh` directory if it exists. This ensures a more user-friendly starting point for selecting SSH keys. (`[src-tauri/src/lib.rsL275-R311](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL275-R311)`)