### PR TITLE
Feat/UI

### DIFF
--- a/docs/status-dot-fix.md
+++ b/docs/status-dot-fix.md
@@ -1,0 +1,99 @@
+# Status Dot Color Fix Summary
+
+## Issues Identified and Fixed
+
+### 1. **CSS Specificity Problems**
+- **Problem**: Status dot colors weren't showing correctly due to CSS specificity issues
+- **Solution**: Made CSS selectors more specific using `.session-status .status-dot` and added `!important` for critical styles
+
+### 2. **Reactivity Issues**
+- **Problem**: Connection status changes weren't triggering Vue's reactivity properly
+- **Solution**: 
+  - Added a computed property `connectionStatuses` to force reactivity
+  - Updated template to use the computed property instead of direct store calls
+  - Ensured proper reactivity binding with Vue's reactive system
+
+### 3. **Inconsistent Status Handling**
+- **Problem**: Different components handled connection status differently
+- **Solution**: Standardized status handling across all components using consistent patterns
+
+## Changes Made
+
+### 1. **Enhanced CSS Specificity**
+```css
+.session-status .status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-secondary);
+  transition: all 0.2s ease;
+}
+
+.session-status .status-dot.connected {
+  background: #28a745 !important;
+  box-shadow: 0 0 6px rgba(40, 167, 69, 0.5);
+}
+
+.session-status .status-dot.connecting {
+  background: #ffc107 !important;
+  animation: pulse 1.5s infinite;
+}
+
+.session-status .status-dot.error {
+  background: #dc3545 !important;
+}
+```
+
+### 2. **Added Reactive Computed Property**
+```typescript
+const connectionStatuses = computed(() => {
+  const statuses: Record<string, string> = {}
+  sessionsStore.sessions.forEach(session => {
+    const status = sessionsStore.getConnectionStatus(session.id)
+    statuses[session.id] = status?.status || 'disconnected'
+  })
+  return statuses
+})
+```
+
+### 3. **Updated Template Bindings**
+```vue
+<div class="status-dot" :class="{
+  'connected': connectionStatuses[session.id] === 'connected',
+  'connecting': connectionStatuses[session.id] === 'connecting',
+  'error': connectionStatuses[session.id] === 'error'
+}"></div>
+```
+
+### 4. **Added Debug Features**
+- Status text display showing current connection state
+- Debug context menu options to test different connection states
+- Visual feedback for troubleshooting
+
+## Status Colors
+
+- 🟢 **Connected**: Green (#28a745) with subtle glow effect
+- 🟡 **Connecting**: Yellow (#ffc107) with pulsing animation
+- 🔴 **Error**: Red (#dc3545) for failed connections
+- ⚪ **Disconnected**: Gray (default) for inactive sessions
+
+## Testing
+
+- Right-click on any session to access debug options
+- Test different connection states using the context menu
+- Visual status indicators update in real-time
+- Status text shows current state for debugging
+
+## Files Modified
+
+1. `src/components/SessionManager.vue`
+   - Enhanced CSS specificity
+   - Added reactive computed properties
+   - Updated template bindings
+   - Added debug functionality
+
+2. `src/components/ContextMenu.vue`
+   - Added debug menu items
+   - Enhanced emit types
+
+The status dots should now correctly display colors based on the actual connection status, with proper reactivity and visual feedback.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "termnest",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1-rc.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4225,7 +4225,7 @@ dependencies = [
 
 [[package]]
 name = "termnest"
-version = "0.1.0"
+version = "0.1.1-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termnest"
-version = "0.1.0"
+version = "0.1.1-rc.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "termnest",
-  "version": "0.1.0",
+  "version": "0.1.1-rc.1",
   "identifier": "com.termnest.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -23,6 +23,19 @@
       Export
     </div>
     <div class="context-menu-separator"></div>
+    <div class="context-menu-item" @click="$emit('test-connected')">
+      <span class="menu-icon">🟢</span>
+      Test Connected
+    </div>
+    <div class="context-menu-item" @click="$emit('test-connecting')">
+      <span class="menu-icon">🟡</span>
+      Test Connecting
+    </div>
+    <div class="context-menu-item" @click="$emit('test-error')">
+      <span class="menu-icon">🔴</span>
+      Test Error
+    </div>
+    <div class="context-menu-separator"></div>
     <div class="context-menu-item danger" @click="$emit('delete')">
       <span class="menu-icon">🗑️</span>
       Delete
@@ -42,6 +55,9 @@ defineEmits<{
   duplicate: []
   export: []
   delete: []
+  'test-connected': []
+  'test-connecting': []
+  'test-error': []
 }>()
 </script>
 

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -9,6 +9,10 @@
       <span class="menu-icon">🔗</span>
       Connect
     </div>
+    <div class="context-menu-item" @click="$emit('new-connection')">
+      <span class="menu-icon">🚀</span>
+      New Connection
+    </div>
     <div class="context-menu-item" @click="$emit('edit')">
       <span class="menu-icon">✏️</span>
       Edit
@@ -51,6 +55,7 @@ defineProps<{
 
 defineEmits<{
   connect: []
+  'new-connection': []
   edit: []
   duplicate: []
   export: []

--- a/src/components/SessionManager.vue
+++ b/src/components/SessionManager.vue
@@ -32,13 +32,25 @@ const filteredSessions = computed(() => {
 })
 
 const recentSessions = computed(() => {
-  return [...sessionsStore.sessions]
-    .sort((a, b) => {
-      const aTime = a.last_used ? new Date(a.last_used).getTime() : 0
-      const bTime = b.last_used ? new Date(b.last_used).getTime() : 0
-      return bTime - aTime
-    })
+  return sessionsStore.sessions
+    .filter(session => session.last_used)
+    .sort((a, b) => new Date(b.last_used!).getTime() - new Date(a.last_used!).getTime())
     .slice(0, 5)
+})
+
+// Force reactivity for connection statuses
+const connectionStatuses = computed(() => {
+  // Explicitly watch the activeConnections object
+  const connections = sessionsStore.activeConnections
+  const statuses: Record<string, string> = {}
+  
+  sessionsStore.sessions.forEach(session => {
+    const status = connections[session.id]
+    statuses[session.id] = status?.status || 'disconnected'
+  })
+  
+  console.log('SessionManager: computed connectionStatuses:', statuses)
+  return statuses
 })
 
 function openCreateModal() {
@@ -146,6 +158,15 @@ function deleteSession() {
       hideContextMenu()
     }
   }
+}
+
+// Debug function to test connection statuses
+function testConnectionStatus(session: Session, status: 'connected' | 'connecting' | 'error' | 'disconnected') {
+  sessionsStore.updateConnectionStatus({
+    session_id: session.id,
+    status: status,
+    message: `Test ${status} status`
+  })
 }
 
 function closeCurrentTab() {
@@ -281,21 +302,26 @@ onUnmounted(() => {
             class="session-item"
             :class="{
               'active': sessionsStore.activeSessions.find(s => s.id === session.id),
-              'connected': sessionsStore.getConnectionStatus(session.id)?.status === 'connected'
+              'connected': connectionStatuses[session.id] === 'connected'
             }"
             @click="openSession(session)"
             @contextmenu="showSessionContextMenu($event, session)"
           >
             <div class="session-status">
               <div class="status-dot" :class="{
-                'connected': sessionsStore.getConnectionStatus(session.id)?.status === 'connected',
-                'connecting': sessionsStore.getConnectionStatus(session.id)?.status === 'connecting',
-                'error': sessionsStore.getConnectionStatus(session.id)?.status === 'error'
+                'connected': connectionStatuses[session.id] === 'connected',
+                'connecting': connectionStatuses[session.id] === 'connecting',
+                'error': connectionStatuses[session.id] === 'error'
               }"></div>
             </div>
             <div class="session-info">
               <div class="session-name">{{ session.name }}</div>
-              <div class="session-details">{{ session.username }}@{{ session.host }}</div>
+              <div class="session-details">
+                {{ session.username }}@{{ session.host }}
+                <span class="status-debug" v-if="connectionStatuses[session.id] !== 'disconnected'">
+                  • {{ connectionStatuses[session.id] }}
+                </span>
+              </div>
             </div>
             <div class="session-protocol">{{ session.protocol }}</div>
           </div>
@@ -316,13 +342,24 @@ onUnmounted(() => {
           <p>No sessions match "{{ searchQuery }}".</p>
         </div>
 
-        <div v-if="sessionsStore.error" class="error-message">
-          <span class="error-icon">⚠️</span>
-          {{ sessionsStore.error }}
-        </div>
-      </div>
+          <div v-if="sessionsStore.error" class="error-message">
+            <span class="error-icon">⚠️</span>
+            {{ sessionsStore.error }}
+          </div>
 
-      <!-- Collapsed sidebar content -->
+          <!-- Debug panel -->
+          <div class="debug-panel" v-if="Object.keys(connectionStatuses).length > 0 && false"> <!-- Debugging disabled -->
+            <h4>Connection Status Debug</h4>
+            <div v-for="(status, sessionId) in connectionStatuses" :key="sessionId" class="debug-item">
+              <span class="debug-session">{{ sessionsStore.sessions.find(s => s.id === sessionId)?.name || sessionId }}</span>
+              <span class="debug-status" :class="status">{{ status }}</span>
+              <div class="debug-actions">
+                <button @click="sessionsStore.setSessionConnected(sessionId)" class="debug-btn connected">✓</button>
+                <button @click="sessionsStore.setSessionDisconnected(sessionId)" class="debug-btn disconnected">✕</button>
+              </div>
+            </div>
+          </div>
+        </div>      <!-- Collapsed sidebar content -->
       <div class="sidebar-collapsed-content" v-else>
         <div class="collapsed-sessions">
           <div
@@ -331,15 +368,15 @@ onUnmounted(() => {
             class="collapsed-session-item"
             :class="{
               'active': sessionsStore.activeSessions.find(s => s.id === session.id),
-              'connected': sessionsStore.getConnectionStatus(session.id)?.status === 'connected'
+              'connected': connectionStatuses[session.id] === 'connected'
             }"
             @click="openSession(session)"
             :title="session.name"
           >
             <div class="status-dot" :class="{
-              'connected': sessionsStore.getConnectionStatus(session.id)?.status === 'connected',
-              'connecting': sessionsStore.getConnectionStatus(session.id)?.status === 'connecting',
-              'error': sessionsStore.getConnectionStatus(session.id)?.status === 'error'
+              'connected': connectionStatuses[session.id] === 'connected',
+              'connecting': connectionStatuses[session.id] === 'connecting',
+              'error': connectionStatuses[session.id] === 'error'
             }"></div>
           </div>
         </div>
@@ -407,6 +444,9 @@ onUnmounted(() => {
       @duplicate="duplicateSession"
       @export="exportSession"
       @delete="deleteSession"
+      @test-connected="() => testConnectionStatus(contextMenuSession!, 'connected')"
+      @test-connecting="() => testConnectionStatus(contextMenuSession!, 'connecting')"
+      @test-error="() => testConnectionStatus(contextMenuSession!, 'error')"
     />
   </div>
 </template>
@@ -589,7 +629,7 @@ onUnmounted(() => {
   flex-shrink: 0;
 }
 
-.status-dot {
+.session-status .status-dot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
@@ -597,18 +637,18 @@ onUnmounted(() => {
   transition: all 0.2s ease;
 }
 
-.status-dot.connected {
-  background: #28a745;
+.session-status .status-dot.connected {
+  background: #28a745 !important;
   box-shadow: 0 0 6px rgba(40, 167, 69, 0.5);
 }
 
-.status-dot.connecting {
-  background: #ffc107;
+.session-status .status-dot.connecting {
+  background: #ffc107 !important;
   animation: pulse 1.5s infinite;
 }
 
-.status-dot.error {
-  background: #dc3545;
+.session-status .status-dot.error {
+  background: #dc3545 !important;
 }
 
 @keyframes pulse {
@@ -636,6 +676,12 @@ onUnmounted(() => {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.status-debug {
+  color: var(--text-accent);
+  font-weight: 500;
+  text-transform: capitalize;
 }
 
 .session-protocol {
@@ -696,6 +742,21 @@ onUnmounted(() => {
   width: 10px;
   height: 10px;
   border: 2px solid var(--bg-secondary);
+  background: var(--text-secondary);
+}
+
+.collapsed-session-item .status-dot.connected {
+  background: #28a745 !important;
+  box-shadow: 0 0 4px rgba(40, 167, 69, 0.5);
+}
+
+.collapsed-session-item .status-dot.connecting {
+  background: #ffc107 !important;
+  animation: pulse 1.5s infinite;
+}
+
+.collapsed-session-item .status-dot.error {
+  background: #dc3545 !important;
 }
 
 .collapsed-add-btn {
@@ -765,6 +826,99 @@ onUnmounted(() => {
 
 .error-icon {
   font-size: 1rem;
+}
+
+/* Debug panel */
+.debug-panel {
+  margin-top: 1rem;
+  padding: 0.75rem;
+  background: var(--bg-primary);
+  border-radius: 6px;
+  border: 1px solid var(--border-color);
+}
+
+.debug-panel h4 {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+}
+
+.debug-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.25rem 0;
+  font-size: 0.75rem;
+  gap: 0.5rem;
+}
+
+.debug-session {
+  color: var(--text-primary);
+  font-weight: 500;
+  flex: 1;
+}
+
+.debug-status {
+  padding: 0.125rem 0.5rem;
+  border-radius: 3px;
+  font-weight: 500;
+  text-transform: uppercase;
+  min-width: 80px;
+  text-align: center;
+}
+
+.debug-actions {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.debug-btn {
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: bold;
+  transition: all 0.2s ease;
+}
+
+.debug-btn.connected {
+  background: #28a745;
+  color: white;
+}
+
+.debug-btn.connected:hover {
+  background: #218838;
+}
+
+.debug-btn.disconnected {
+  background: #dc3545;
+  color: white;
+}
+
+.debug-btn.disconnected:hover {
+  background: #c82333;
+}
+
+.debug-status.connected {
+  background: rgba(40, 167, 69, 0.1);
+  color: #28a745;
+}
+
+.debug-status.connecting {
+  background: rgba(255, 193, 7, 0.1);
+  color: #ffc107;
+}
+
+.debug-status.error {
+  background: rgba(220, 53, 69, 0.1);
+  color: #dc3545;
+}
+
+.debug-status.disconnected {
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
 }
 
 /* Main content area */

--- a/src/components/TabsContainer.vue
+++ b/src/components/TabsContainer.vue
@@ -9,9 +9,9 @@
           class="tab"
           :class="{ 
             'active': session.id === currentActiveSessionId,
-            'connected': getConnectionStatus(session.id)?.status === 'connected',
-            'connecting': getConnectionStatus(session.id)?.status === 'connecting',
-            'error': getConnectionStatus(session.id)?.status === 'error'
+            'connected': tabConnectionStatuses[session.id] === 'connected',
+            'connecting': tabConnectionStatuses[session.id] === 'connecting',
+            'error': tabConnectionStatuses[session.id] === 'error'
           }"
           @click="switchToSession(session.id)"
         >
@@ -119,6 +119,20 @@ const availableSessions = computed(() => {
   )
 })
 
+// Force reactivity for connection statuses in tabs
+const tabConnectionStatuses = computed(() => {
+  const connections = sessionsStore.activeConnections
+  const statuses: Record<string, string> = {}
+  
+  activeSessions.value.forEach(session => {
+    const status = connections[session.id]
+    statuses[session.id] = status?.status || 'disconnected'
+  })
+  
+  console.log('TabsContainer: computed tabConnectionStatuses:', statuses)
+  return statuses
+})
+
 function switchToSession(sessionId: string) {
   sessionsStore.switchToSession(sessionId)
 }
@@ -131,10 +145,6 @@ function closeSessionTab(sessionId: string) {
   }
   // Close the tab
   sessionsStore.closeSession(sessionId)
-}
-
-function getConnectionStatus(sessionId: string) {
-  return sessionsStore.getConnectionStatus(sessionId)
 }
 
 function showSessionSelector() {

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -269,7 +269,12 @@ async function initializeTerminal() {
   try {
     connectionStatus.value = 'connecting'
     
-    const session = sessionsStore.sessions.find(s => s.id === props.sessionId)
+    // For additional connections, extract the original session ID
+    const originalSessionId = props.sessionId.includes('_conn_') 
+      ? props.sessionId.split('_conn_')[0] 
+      : props.sessionId
+    
+    const session = sessionsStore.sessions.find(s => s.id === originalSessionId)
     if (!session) {
       throw new Error('Session not found')
     }
@@ -320,7 +325,12 @@ async function initializeTerminal() {
 }
 
 async function getSessionConfig() {
-  const session = sessionsStore.sessions.find(s => s.id === props.sessionId)
+  // For additional connections, extract the original session ID
+  const originalSessionId = props.sessionId.includes('_conn_') 
+    ? props.sessionId.split('_conn_')[0] 
+    : props.sessionId
+    
+  const session = sessionsStore.sessions.find(s => s.id === originalSessionId)
   if (!session) {
     throw new Error('Session not found')
   }

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -250,8 +250,18 @@ function updateConnectionProgress(status: string, message?: string) {
   } else if (status === 'connected') {
     currentStepIndex.value = connectionSteps.value.length - 1
     connectionStatus.value = 'connected'
+    sessionsStore.updateConnectionStatus({
+      session_id: props.sessionId,
+      status: 'connected',
+      message: 'Connection established'
+    })
   } else if (status === 'disconnected') {
     connectionStatus.value = 'disconnected'
+    sessionsStore.updateConnectionStatus({
+      session_id: props.sessionId,
+      status: 'disconnected',
+      message: 'Connection closed'
+    })
   }
 }
 
@@ -286,6 +296,11 @@ async function initializeTerminal() {
     })
     
     connectionStatus.value = 'connected'
+    sessionsStore.updateConnectionStatus({
+      session_id: props.sessionId,
+      status: 'connected',
+      message: 'SSH connection established'
+    })
     
     if (props.protocol === 'SSH') {
       await loadRemoteFiles()
@@ -293,6 +308,11 @@ async function initializeTerminal() {
   } catch (error) {
     console.error('Failed to initialize terminal:', error)
     connectionStatus.value = 'disconnected'
+    sessionsStore.updateConnectionStatus({
+      session_id: props.sessionId,
+      status: 'disconnected',
+      message: 'Failed to connect: ' + error
+    })
     if (terminal) {
       terminal.write('Failed to connect: ' + error + '\r\n')
     }
@@ -557,6 +577,11 @@ async function handlePasswordAuthentication(password: string) {
     // Success - close dialog and update status
     showPasswordDialog.value = false
     connectionStatus.value = 'connected'
+    sessionsStore.updateConnectionStatus({
+      session_id: props.sessionId,
+      status: 'connected',
+      message: 'SSH connection established via password'
+    })
     isAuthenticating.value = false
     pendingSessionConfig.value = null
     
@@ -573,6 +598,11 @@ async function handlePasswordAuthentication(password: string) {
 function handlePasswordCancel() {
   showPasswordDialog.value = false
   connectionStatus.value = 'disconnected'
+  sessionsStore.updateConnectionStatus({
+    session_id: props.sessionId,
+    status: 'disconnected',
+    message: 'Password authentication cancelled'
+  })
   pendingSessionConfig.value = null
   passwordDialogError.value = ''
   isAuthenticating.value = false
@@ -592,6 +622,11 @@ function disconnect() {
   
   // Update local state
   connectionStatus.value = 'disconnected'
+  sessionsStore.updateConnectionStatus({
+    session_id: props.sessionId,
+    status: 'disconnected',
+    message: 'Session disconnected'
+  })
   
   // Close the session and go back to sessions list
   sessionsStore.closeSession()


### PR DESCRIPTION
This pull request introduces several updates to improve the handling of connection statuses, enhance debugging features, and update the versioning across the project. The most significant changes include fixing CSS specificity issues for status dots, adding reactive properties for better Vue reactivity, enhancing the session management logic, and introducing debug tools for connection statuses.

### Connection Status and Reactivity Improvements:
* **CSS Fixes for Status Dots**: Improved CSS specificity for `.status-dot` elements using `.session-status .status-dot` and added `!important` to critical styles to resolve color inconsistencies. [[1]](diffhunk://#diff-7c0b481e89e9baf4dc64489065ed60afe802cdb8d2078b173ee35774041124feR1-R99) [[2]](diffhunk://#diff-387bec4a1af83d5087ad7d1b2e07cee4a1e70c6fa276668cc568b8d769a26b91L592-R706) [[3]](diffhunk://#diff-387bec4a1af83d5087ad7d1b2e07cee4a1e70c6fa276668cc568b8d769a26b91R818-R832)
* **Reactive Computed Properties**: Introduced `connectionStatuses` and `connectionCounts` computed properties in `SessionManager.vue` to ensure proper reactivity and accurate connection status tracking. [[1]](diffhunk://#diff-7c0b481e89e9baf4dc64489065ed60afe802cdb8d2078b173ee35774041124feR1-R99) [[2]](diffhunk://#diff-387bec4a1af83d5087ad7d1b2e07cee4a1e70c6fa276668cc568b8d769a26b91L35-R71)
* **Template Updates**: Updated bindings in `SessionManager.vue` to use the new reactive properties for connection statuses and added UI elements like connection badges and debug status indicators. [[1]](diffhunk://#diff-387bec4a1af83d5087ad7d1b2e07cee4a1e70c6fa276668cc568b8d769a26b91L284-R378) [[2]](diffhunk://#diff-387bec4a1af83d5087ad7d1b2e07cee4a1e70c6fa276668cc568b8d769a26b91L323-R416) [[3]](diffhunk://#diff-387bec4a1af83d5087ad7d1b2e07cee4a1e70c6fa276668cc568b8d769a26b91R754-R759)

### Debugging Enhancements:
* **Debug Menu Options**: Added context menu options to test different connection states (`Test Connected`, `Test Connecting`, `Test Error`) and implemented corresponding emit events in `ContextMenu.vue`. [[1]](diffhunk://#diff-cbb365aed62d6b65203fae7e19e93928abc118a6d1f2578c652e248ba87a6a18R30-R42) [[2]](diffhunk://#diff-cbb365aed62d6b65203fae7e19e93928abc118a6d1f2578c652e248ba87a6a18R58-R65)
* **Debug Panel**: Added a debug panel in `SessionManager.vue` to display and manipulate connection statuses for troubleshooting. [[1]](diffhunk://#diff-387bec4a1af83d5087ad7d1b2e07cee4a1e70c6fa276668cc568b8d769a26b91L323-R416) [[2]](diffhunk://#diff-387bec4a1af83d5087ad7d1b2e07cee4a1e70c6fa276668cc568b8d769a26b91R904-R996)

### Session Management Enhancements:
* **New Connection Handling**: Enabled creating additional connections for active sessions with unique IDs and timestamps. [[1]](diffhunk://#diff-387bec4a1af83d5087ad7d1b2e07cee4a1e70c6fa276668cc568b8d769a26b91R100-R118) [[2]](diffhunk://#diff-387bec4a1af83d5087ad7d1b2e07cee4a1e70c6fa276668cc568b8d769a26b91R162-R177)
* **Session Context Menu**: Added a `New Connection` option to the context menu for creating additional connections directly. [[1]](diffhunk://#diff-cbb365aed62d6b65203fae7e19e93928abc118a6d1f2578c652e248ba87a6a18R12-R15) [[2]](diffhunk://#diff-387bec4a1af83d5087ad7d1b2e07cee4a1e70c6fa276668cc568b8d769a26b91R497-R504)

### Version Updates:
* Updated the project version to `0.1.1-rc.1` in `package.json`, `Cargo.toml`, and `tauri.conf.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39L3-R3) [[3]](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L4-R4)

### Minor UI Enhancements:
* **Version Display**: Added a clickable version display in `StatusBar.vue` to check for updates with an indicator for new versions.
* **Improved Styling**: Introduced new styles for connection badges, debug indicators, and status elements to improve the visual feedback. [[1]](diffhunk://#diff-387bec4a1af83d5087ad7d1b2e07cee4a1e70c6fa276668cc568b8d769a26b91R726-R743) [[2]](diffhunk://#diff-387bec4a1af83d5087ad7d1b2e07cee4a1e70c6fa276668cc568b8d769a26b91R904-R996)