### PR TITLE
Sync PTY size with frontend terminal

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -853,6 +853,7 @@ pub fn run() {
             ssh_new::ssh_connect,
             ssh_new::ssh_connect_with_password,
             ssh_new::ssh_send_input,
+            ssh_new::ssh_resize_terminal,
             ssh_new::ssh_disconnect,
             ssh_new::ssh_list_sessions
         ])

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
-import { invoke } from '@tauri-apps/api/core'
 import { useSessionsStore } from './stores/sessions'
 import { useSettingsStore } from './stores/settings'
 import SessionManager from './components/SessionManager.vue'
@@ -10,18 +9,6 @@ import StatusBar from './components/StatusBar.vue'
 const sessionsStore = useSessionsStore()
 const settingsStore = useSettingsStore()
 const showSettingsModal = ref(false)
-
-async function testTauriConnection() {
-  try {
-    console.log('Testing Tauri connection...')
-    const result = await invoke('greet', { name: 'Test' })
-    console.log('Tauri connection test result:', result)
-    alert('Tauri connection working: ' + result)
-  } catch (error) {
-    console.error('Tauri connection test failed:', error)
-    alert('Tauri connection failed: ' + error)
-  }
-}
 
 onMounted(async () => {
   console.log('App: Mounting application...')

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -312,6 +312,28 @@ const connectionStatus = ref<'connecting' | 'connected' | 'disconnected'>('conne
 let terminal: Terminal | null = null
 let fitAddon: FitAddon | null = null
 
+async function fitTerminal() {
+  if (fitAddon && terminal) {
+    try {
+      fitAddon.fit()
+      const cols = terminal.cols
+      const rows = terminal.rows
+      try {
+        await invoke('ssh_resize_terminal', {
+          sessionId: props.sessionId,
+          cols,
+          rows
+        })
+        console.log(`Terminal resized to ${cols}x${rows}`)
+      } catch (error) {
+        console.warn('Failed to resize backend terminal:', error)
+      }
+    } catch (error) {
+      console.warn('Terminal resize failed:', error)
+    }
+  }
+}
+
 // Connection log state
 const connectionSteps = ref([
   'Establishing TCP connection',
@@ -491,7 +513,9 @@ async function initializeTerminal() {
       status: 'connected',
       message: 'SSH connection established'
     })
-    
+
+    await fitTerminal()
+
     if (props.protocol === 'SSH') {
       await loadRemoteFiles()
     }
@@ -595,9 +619,7 @@ function setupTerminal() {
   
   // Fit terminal to container size
   setTimeout(() => {
-    if (fitAddon) {
-      fitAddon.fit()
-    }
+    fitTerminal()
   }, 0)
   
   // Handle user input
@@ -620,48 +642,19 @@ function setupTerminal() {
       clearTimeout(resizeTimeout)
     }
     resizeTimeout = window.setTimeout(async () => {
-      if (fitAddon && terminal) {
-        try {
-          fitAddon.fit()
-          console.log(`Terminal fitted to container: ${terminal.cols}x${terminal.rows}`)
-        } catch (error) {
-          console.warn('Terminal resize failed:', error)
-        }
-      }
+      fitTerminal()
     }, 100) // Increased debounce time for better performance
   })
   
   resizeObserver.observe(terminalContainer.value)
   
   // Also handle window resize
-  const handleWindowResize = async () => {
+  const handleWindowResize = () => {
     if (resizeTimeout) {
       clearTimeout(resizeTimeout)
     }
-    resizeTimeout = window.setTimeout(async () => {
-      if (fitAddon && terminal) {
-        try {
-          fitAddon.fit()
-          
-          // Get terminal dimensions and notify backend
-          const cols = terminal.cols
-          const rows = terminal.rows
-          
-          // Send resize to backend
-          try {
-            await invoke('ssh_resize_terminal', {
-              sessionId: props.sessionId,
-              cols: cols,
-              rows: rows
-            })
-            console.log(`Terminal window resized to ${cols}x${rows}`)
-          } catch (error) {
-            console.warn('Failed to resize backend terminal on window resize:', error)
-          }
-        } catch (error) {
-          console.warn('Terminal window resize failed:', error)
-        }
-      }
+    resizeTimeout = window.setTimeout(() => {
+      fitTerminal()
     }, 150) // Slightly longer delay for window resize
   }
   
@@ -695,9 +688,7 @@ function toggleSftp() {
   
   // Resize terminal after SFTP panel toggle
   setTimeout(() => {
-    if (fitAddon && terminal) {
-      fitAddon.fit()
-    }
+    fitTerminal()
   }, 300) // Wait for animation to complete
 }
 
@@ -707,9 +698,7 @@ function closeSftp() {
   
   // Resize terminal after closing SFTP
   setTimeout(() => {
-    if (fitAddon && terminal) {
-      fitAddon.fit()
-    }
+    fitTerminal()
   }, 100)
 }
 
@@ -1104,7 +1093,7 @@ function disconnect() {
 
 <style scoped>
 .terminal-container {
-  height: calc(100vh - 40px); /* Account for window titlebar and borders */
+  height: 100vh;
   display: flex;
   flex-direction: column;
   background: #1e1e1e;
@@ -1128,7 +1117,7 @@ function disconnect() {
   display: flex;
   overflow: hidden;
   min-height: 0;
-  height: calc(100vh - 120px); /* Account for titlebar + header + some padding */
+  /* Let flex layout determine remaining height to avoid clipping */
 }
 
 .terminal-wrapper {
@@ -1309,8 +1298,7 @@ function disconnect() {
   overflow: hidden; /* Let xterm.js handle scrolling */
   cursor: text;
   min-height: 0; /* Important for flex child */
-  height: 100%; /* Ensure full height usage */
-  max-height: calc(100vh - 160px); /* Reserve space for header and controls, prevent bottom overflow */
+  /* Allow terminal to fill available vertical space */
 }
 
 .terminal-simulation {


### PR DESCRIPTION
## Summary
- add backend PTY resize command and store channel for resizing
- ensure Terminal.vue fits viewport and notifies backend on every resize
- remove unused App debug function causing TS build error
- let Terminal.vue occupy full height so nano footer stays visible

## Testing
- `pnpm build`
- `cargo check` *(terminated while compiling openssl-sys v0.9.109)*